### PR TITLE
remove require 'rack/conditionalget'

### DIFF
--- a/lib/travis/sso/generic.rb
+++ b/lib/travis/sso/generic.rb
@@ -2,7 +2,6 @@ require 'travis/sso'
 
 require 'rack/request'
 require 'rack/file'
-require 'rack/conditionalget'
 
 require 'multi_json'
 require 'open-uri'


### PR DESCRIPTION
due to renaming of a file in rack in newer versions this would throw an
error, but requiring is not necessary due to autoloading:
in rack autoload :ConditionalGet, "rack/conditionalget" (older version)
or "rack/conditional_get" (newer version)