### PR TITLE
use require 'rack'

### DIFF
--- a/lib/travis/sso/generic.rb
+++ b/lib/travis/sso/generic.rb
@@ -1,8 +1,6 @@
 require 'travis/sso'
 
-require 'rack/request'
-require 'rack/file'
-
+require 'rack'
 require 'multi_json'
 require 'open-uri'
 require 'rotp'


### PR DESCRIPTION
Previous PR #9 removed `require 'rack/conditionalget'`
@rhk stated be sure it is loaded, we should add `require 'rack'`

`require 'rack/request'` and `require 'rack/file'` then are not necessary they are also autoloaded in rack.rb. So I removed them as well.