### PR TITLE
Try setting clear site data header to empty

### DIFF
--- a/lib/travis/sso/session.rb
+++ b/lib/travis/sso/session.rb
@@ -12,7 +12,7 @@ module Travis
       end
 
       def pass(request)
-        response(303, 'Location' => request.url)
+        response(303, 'Location' => request.url, 'Clear-Site-Data' => '')
       end
 
       def set_user(request, user)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,6 @@ end
 
 RSpec.configure do |c|
   c.color = true
-  c.expect_with :rspec, :stdlib
   c.mock_with :flexmock
   c.include Helpers
 

--- a/spec/sso/helpers_spec.rb
+++ b/spec/sso/helpers_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Travis::SSO::Helpers do
-  subject { Object.new.extend(described_class) }
+  subject { Object.new.extend(Travis::SSO::Helpers) }
 
   def current_user
     subject.current_user


### PR DESCRIPTION
It _seems_ like Chrome 61 introduced experimental support for [Clear-Site-Data](https://www.chromestatus.com/feature/4713262029471744) and this may be having the effect that our billing cookie is cleared after it is initially set, resulting in an infinite auth redirect.

This PR is for testing on staging.

See https://secure.helpscout.net/conversation/430330552/59586/?folderId=30784