### PR TITLE
Update test dependencies + fix and cleanup tests + Build in Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,4 @@ end
 
 group :test do
   gem 'rspec'
-  gem 'flexmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,52 @@
+PATH
+  remote: .
+  specs:
+    travis-sso (0.0.1)
+      multi_json
+      rack
+      rotp
+      yubikey
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    multi_json (1.13.1)
+    mustermann (1.0.2)
+    rack (2.0.5)
+    rack-protection (2.0.3)
+      rack
+    rake (12.3.1)
+    rotp (3.3.1)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    sinatra (2.0.3)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.3)
+      tilt (~> 2.0)
+    tilt (2.0.8)
+    yubikey (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rspec
+  sinatra
+  travis-sso!
+
+BUNDLED WITH
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Travis::SSO
+# Travis::SSO [![Build Status](https://travis-ci.com/travis-ci/travis-sso.svg?branch=master)](https://travis-ci.com/travis-ci/travis-sso)
 
 Implements Travis CI Single Sign-On as a Rack middleware.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,28 +4,6 @@ require 'rspec'
 require 'travis/sso'
 require 'sinatra/base'
 
-class Object
-  # This little hack makes flexmock largely compatible with rspec-mock and mocha.
-  def should_receive(*args, &block)
-    example = Thread.current[:example]
-    fail "not in any rspec example" unless example
-    example.flexmock(self).should_receive(*args, &block)
-  end
-end
-
-module Helpers
-  def stub!(methods = {})
-    flexmock(subject, methods)
-  end
-end
-
 RSpec.configure do |c|
   c.color = true
-  c.expect_with :rspec, :stdlib
-  c.mock_with :flexmock
-  c.include Helpers
-
-  # see Object#should_receive
-  c.before(:each) { Thread.current[:example] = self }
-  c.after(:each) { Thread.current[:example] = nil }
 end

--- a/spec/sso/helpers_spec.rb
+++ b/spec/sso/helpers_spec.rb
@@ -3,98 +3,96 @@ require 'spec_helper'
 describe Travis::SSO::Helpers do
   subject { Object.new.extend(described_class) }
 
-  def current_user
-    subject.current_user
-  end
+  let(:current_user) { subject.current_user }
 
-  describe :user_class do
+  context 'user_class' do
     after(:each) do
       Travis.send(:remove_const, :User) if defined? Travis::User
       Object.send(:remove_const, :User) if defined? ::User
     end
 
     it 'defaults to OpenStruct' do
-      Travis::SSO::Helpers.user_class.should be == OpenStruct
+      expect(Travis::SSO::Helpers.user_class).to eq(OpenStruct)
     end
 
     it 'picks User if available' do
       User = 42
-      Travis::SSO::Helpers.user_class.should be == 42
+      expect(Travis::SSO::Helpers.user_class).to eq(42)
     end
 
     it 'picks Travis::User if available' do
       Travis::User = 42
-      Travis::SSO::Helpers.user_class.should be == 42
+      expect(Travis::SSO::Helpers.user_class).to eq(42)
     end
   end
 
-  describe :current_user do
+  describe 'current_user' do
     it 'complains if there is no request info available' do
       expect { current_user }.to raise_error(NameError, /request/)
     end
 
     it 'takes the user id from session["user_id"]' do
-      stub! :session => { 'user_id' => 42 }
-      current_user.id.should be == 42
+      allow(subject).to receive(:session).and_return({ 'user_id' => 42 })
+      expect(current_user.id).to eq(42)
     end
 
     it 'takes the user id from env["rack.session"]["user_id"]' do
-      stub! :env => { 'rack.session' => { 'user_id' => 42 }}
-      current_user.id.should be == 42
+      allow(subject).to receive(:env).and_return({ 'rack.session' => { 'user_id' => 42 }})
+      expect(current_user.id).to eq(42)
     end
 
     it 'takes the user id from request.env["rack.session"]["user_id"]' do
-      request = flexmock('request', :env => { 'rack.session' => { 'user_id' => 42 }})
-      stub! :request => request
-      current_user.id.should be == 42
+      request = double(:request, :env => { 'rack.session' => { 'user_id' => 42 }})
+      allow(subject).to receive(:request).and_return(request)
+      expect(current_user.id).to eq(42)
     end
 
     it 'takes the user id from env["travis.user_info"]["id"]' do
-      stub! :env => { 'travis.user_info' => { 'id' => 42 }}
-      current_user.id.should be == 42
+      allow(subject).to receive(:env).and_return({ 'travis.user_info' => { 'id' => 42 }})
+      expect(current_user.id).to eq(42)
     end
 
     it 'does not complain about a missing user' do
-      stub! :env => {}
-      current_user.should be_nil
+      allow(subject).to receive(:env).and_return({})
+      expect(current_user).to be_nil
     end
 
     it 'merges env and session info' do
-      stub! :env => {
+      allow(subject).to receive(:env).and_return({
         'rack.session'     => { 'user_id' => 1337    },
         'travis.user_info' => { 'name'    => 'Klaus' }
-      }
-      current_user.id.should   be == 1337
-      current_user.name.should be == 'Klaus'
+      })
+      expect(current_user.id).to eq(1337)
+      expect(current_user.name).to eq('Klaus')
     end
 
     it 'does not set a user without an id' do
-      stub! :env => { 'travis.user_info' => { 'name' => 'Klaus' } }
-      current_user.should be_nil
+      allow(subject).to receive(:env).and_return({ 'travis.user_info' => { 'name' => 'Klaus' } })
+      expect(current_user).to be_nil
     end
 
     it 'uses Travis::SSO::Helpers.user_class' do
       subclass = Class.new(OpenStruct)
-      Travis::SSO::Helpers.should_receive(:user_class).and_return(subclass)
+      expect(Travis::SSO::Helpers).to receive(:user_class).and_return(subclass)
 
-      stub! :session => { 'user_id' => 42 }
-      current_user.should be_a(subclass)
+      allow(subject).to receive(:session).and_return({ 'user_id' => 42 })
+      expect(current_user).to be_a(subclass)
     end
 
     it 'calls find_by_id(id) on the user_class if avaiable' do
       subclass = Class.new
-      Travis::SSO::Helpers.should_receive(:user_class).and_return(subclass)
-      subclass.should_receive(:find_by_id).with(42).and_return("Klaus")
+      expect(Travis::SSO::Helpers).to receive(:user_class).and_return(subclass)
+      expect(subclass).to receive(:find_by_id).with(42).and_return("Klaus")
 
-      stub! :session => { 'user_id' => 42 }
-      current_user.should be == "Klaus"
+      allow(subject).to receive(:session).and_return({ 'user_id' => 42 })
+      expect(current_user).to eq("Klaus")
     end
   end
 
-  describe :user do
+  describe 'user' do
     it 'calls current_user' do
-      stub! :current_user => 42
-      subject.user.should be == 42
+      allow(subject).to receive(:current_user).and_return(42)
+      expect(subject.user).to eq(42)
     end
   end
 end

--- a/spec/sso_spec.rb
+++ b/spec/sso_spec.rb
@@ -8,19 +8,19 @@ describe Travis::SSO do
     end
 
     it 'maps session mode to Travis::SSO::Session' do
-      Travis::SSO.new(nil, :mode => :session).should be_a(Travis::SSO::Session)
+      expect(Travis::SSO.new(nil, :mode => :session)).to be_a(Travis::SSO::Session)
     end
 
     it 'maps single_page mode to Travis::SSO::SinglePage' do
-      Travis::SSO.new(nil, :mode => :single_page).should be_a(Travis::SSO::SinglePage)
+      expect(Travis::SSO.new(nil, :mode => :single_page)).to be_a(Travis::SSO::SinglePage)
     end
 
     it 'maps callback mode to Travis::SSO::Session' do
-      Travis::SSO.new(nil, callbacks.merge(:mode => :callback)).should be_a(Travis::SSO::Callback)
+      expect(Travis::SSO.new(nil, callbacks.merge(:mode => :callback))).to be_a(Travis::SSO::Callback)
     end
 
     it 'defaults to callback mode' do
-      Travis::SSO.new(nil, callbacks).should be_a(Travis::SSO::Callback)
+      expect(Travis::SSO.new(nil, callbacks)).to be_a(Travis::SSO::Callback)
     end
 
     it 'raises if neither mode nor callbacks are given' do
@@ -34,31 +34,31 @@ describe Travis::SSO do
 
     it 'pipes white listed routes right through' do
       sso = Travis::SSO::Generic.new(app, whitelist: '/foo/bar')
-      app.should_receive(:call).once
+      expect(app).to receive(:call).once
       sso.send(:whitelisted, request)
     end
 
     it 'accepts patterns' do
       sso = Travis::SSO::Generic.new(app, whitelist: '/foo/*')
-      app.should_receive(:call).once
+      expect(app).to receive(:call).once
       sso.send(:whitelisted, request)
     end
 
     it 'accepts regexps' do
       sso = Travis::SSO::Generic.new(app, whitelist: /foo/)
-      app.should_receive(:call).once
+      expect(app).to receive(:call).once
       sso.send(:whitelisted, request)
     end
 
     it 'accepts arrays' do
       sso = Travis::SSO::Generic.new(app, whitelist: ['/bar', /foo/])
-      app.should_receive(:call).once
+      expect(app).to receive(:call).once
       sso.send(:whitelisted, request)
     end
 
     it 'reject non-matching routes' do
       sso = Travis::SSO::Generic.new(app, whitelist: '/foo')
-      app.should_receive(:call).never
+      expect(app).to_not receive(:call)
       sso.send(:whitelisted, request)
     end
   end
@@ -68,21 +68,21 @@ describe Travis::SSO do
     let(:middleware) { app.middleware.map(&:first) }
 
     it 'pulls in helpers' do
-      app.ancestors.should include(Travis::SSO::Helpers)
+      expect(app.ancestors).to include(Travis::SSO::Helpers)
     end
 
     it 'sets up the middleware' do
-      middleware.should include(Travis::SSO)
+      expect(middleware).to include(Travis::SSO)
     end
 
     it 'defaults to single_page mode' do
-      Travis::SSO::SinglePage.should_receive(:new).once.pass_thru
+      expect(Travis::SSO::SinglePage).to receive(:new).once.and_call_original
       app.new
     end
 
     it 'chooses session mode if sessions are enabled' do
-      Travis::SSO::SinglePage.should_receive(:new).never
-      Travis::SSO::Session.should_receive(:new).once.pass_thru
+      expect(Travis::SSO::SinglePage).to_not receive(:new)
+      expect(Travis::SSO::Session).to receive(:new).once.and_call_original
       app.enable :sessions
       app.new
     end


### PR DESCRIPTION
From first commit message:

> I wanted to fix something and start from a green test run, but many were
failing in my machine. This are the changes I made to turn the test run
green:
>
> * Add Gemfile.lock (it was .gitignored before so I don't know with which
versions did the last successful build run) with current versions of
everything
> * Fix some things that were broken in the current version of rspec
(mainly, removing `expect_with :stdlib`, which wasn't used anyway)
> * Related, remove deprecation warnings by switching from `.should_*`
assertions to `expect(...).to ...`
> * Also related, the workaround to use flexmock gave me troubles after
updating, so I took the opportunity to remove the flexmock dependency
and use rspec builtin mocks (very little changes required)

I also thought that we could use this cool CI service called Travis so I set it up :wink: 